### PR TITLE
IT-4010: Increase minimum number of tasks

### DIFF
--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -133,7 +133,7 @@ class DockerFargateStack(Stack):
             f'{stack_prefix}-Service',
             cluster=cluster,            # Required
             cpu=256,                    # Default is 256
-            desired_count=1,            # Number of copies of the 'task' (i.e. the app') running behind the ALB
+            desired_count=2,            # Number of copies of the 'task' (i.e. the app') running behind the ALB
             circuit_breaker=ecs.DeploymentCircuitBreaker(rollback=True), # Enable rollback on deployment failure
             task_image_options=task_image_options,
             memory_limit_mib=1024,      # Default is 512
@@ -147,7 +147,7 @@ class DockerFargateStack(Stack):
         )
 
         scalable_target = load_balanced_fargate_service.service.auto_scale_task_count(
-           min_capacity=1, # Minimum capacity to scale to. Default: 1
+           min_capacity=2, # Minimum capacity to scale to. Default: 1
            max_capacity=4 # Maximum capacity to scale to.
         )
 


### PR DESCRIPTION
We had an outage in the Docker container registry.  To mitigate the risk of future outages we will increase the minimum number of tasks (container instances) from 1 to 2.