### PR TITLE
IT-4010: Increase CPU and memory of registry task

### DIFF
--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -132,11 +132,11 @@ class DockerFargateStack(Stack):
             self,
             f'{stack_prefix}-Service',
             cluster=cluster,            # Required
-            cpu=256,                    # Default is 256
+            cpu=2048,                   # Default is 256
             desired_count=2,            # Number of copies of the 'task' (i.e. the app') running behind the ALB
             circuit_breaker=ecs.DeploymentCircuitBreaker(rollback=True), # Enable rollback on deployment failure
             task_image_options=task_image_options,
-            memory_limit_mib=1024,      # Default is 512
+            memory_limit_mib=4096,      # Default is 512
             public_load_balancer=True,  # Default is False
             redirect_http=True,
             # TLS:


### PR DESCRIPTION
In IT-4010, the server fails when pushing a large image. The change is to make the tasks match the CPU and memory of the previous infrastructure.  If this fixes the problem in the 'dev' environment we will deploy to prod.