### PR TITLE
IT-4010: add http/secret parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@ We use the [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/late
 In dev the secret is named `registry-dev-DockerFargateStack/dev/ecs` and in the prod stack,
 `registry-prod-DockerFargateStack/prod/ecs`
 
-A secret is a collection of key-value pairs.  For this application there is just one pair.  The key should be `notification_auth` and the value is the
+A secret is a collection of key-value pairs.  For this application there are two pairs.  The key for the first should be `notification_auth` and the value is the
 Base64 encoded "Basic auth" credentials which are a shared-secret with Synapse as the event notification recipient.
+The key for the second should be 'http_secret' and the value is a cryptogrphically generated string for use by the
+server as described [here](https://distribution.github.io/distribution/about/configuration/).
 
 ### Registry container
 We use the open source Docker `registry`, available on DockerHub.  This container requires several configuration files to be mounted.

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -31,11 +31,11 @@ CERTIFICATE_FILE_NAME = "certificate.pem"
 
 BUCKET_NAME = "BUCKET_NAME"
 
-SECRET_JSON_KEY="notification_auth"
+NOTIFICATION_AUTH_SECRET_JSON_KEY="notification_auth"
+HTTP_SECRET_SECRET_JSON_KEY="http_secret"
 
-def get_secret(scope: Construct, id: str, name: str, secret_json_key) -> str:
-    isecret = sm.Secret.from_secret_name_v2(scope, id, name)
-    return ecs.Secret.from_secrets_manager(isecret, secret_json_key)
+def get_secret(scope: Construct, id: str, name: str) -> str:
+    return sm.Secret.from_secret_name_v2(scope, id, name)
     # see also: https://docs.aws.amazon.com/cdk/api/v1/python/aws_cdk.aws_ecs/Secret.html
     # see also: ecs.Secret.from_ssm_parameter(ssm.IParameter(parameter_name=name))
 
@@ -92,8 +92,12 @@ class DockerFargateStack(Stack):
             container_insights=True)
 
         secret_name = f'{env.get(config.STACK_NAME_PREFIX_CONTEXT)}-DockerFargateStack/{context}/ecs'
+        sm_secret = get_secret(self, secret_name, secret_name)
         secrets = {
-            SECRET_JSON_KEY: get_secret(self, secret_name, secret_name, SECRET_JSON_KEY),
+            NOTIFICATION_AUTH_SECRET_JSON_KEY: 
+                ecs.Secret.from_secrets_manager(sm_secret, NOTIFICATION_AUTH_SECRET_JSON_KEY),
+            HTTP_SECRET_SECRET_JSON_KEY: 
+            	ecs.Secret.from_secrets_manager(sm_secret, HTTP_SECRET_SECRET_JSON_KEY),
             "AWS_SECRET_ACCESS_KEY": ecs.Secret.from_secrets_manager(secret_stored_access_key)
         }
 

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -94,10 +94,10 @@ class DockerFargateStack(Stack):
         secret_name = f'{env.get(config.STACK_NAME_PREFIX_CONTEXT)}-DockerFargateStack/{context}/ecs'
         sm_secret = get_secret(self, secret_name, secret_name)
         secrets = {
-            NOTIFICATION_AUTH_SECRET_JSON_KEY: 
+            NOTIFICATION_AUTH_SECRET_JSON_KEY:
                 ecs.Secret.from_secrets_manager(sm_secret, NOTIFICATION_AUTH_SECRET_JSON_KEY),
-            HTTP_SECRET_SECRET_JSON_KEY: 
-            	ecs.Secret.from_secrets_manager(sm_secret, HTTP_SECRET_SECRET_JSON_KEY),
+            HTTP_SECRET_SECRET_JSON_KEY:
+                ecs.Secret.from_secrets_manager(sm_secret, HTTP_SECRET_SECRET_JSON_KEY),
             "AWS_SECRET_ACCESS_KEY": ecs.Secret.from_secrets_manager(secret_stored_access_key)
         }
 

--- a/resources/dev/config.yml
+++ b/resources/dev/config.yml
@@ -15,6 +15,7 @@ http:
     tls:
         certificate: /etc/docker/registry/ssl/certificate.pem
         key: /etc/docker/registry/ssl/privatekey.pem
+    secret: http_secret
 
 storage:
     cache:

--- a/resources/prod/config.yml
+++ b/resources/prod/config.yml
@@ -15,6 +15,7 @@ http:
     tls:
         certificate: /etc/docker/registry/ssl/certificate.pem
         key: /etc/docker/registry/ssl/privatekey.pem
+    secret: http_secret
 
 storage:
     cache:

--- a/startup.sh
+++ b/startup.sh
@@ -1,5 +1,10 @@
 #!/bin/sh
 
+# Inject http_secret into config.yml
+# The value is taken from the environment variable, `http_secret` which,
+# during ECS deployment comes from the AWS Secrets Manager.
+sed -i "s/http_secret/$http_secret/g" /etc/docker/registry/config.yml
+
 # Inject notification listener authorization credentials into config.yml
 # The value is taken from the environment variable, `notification_auth` which,
 # during ECS deployment comes from the AWS Secrets Manager.


### PR DESCRIPTION
Multiple servers behind an LB will not work without the http/secret parameter.  From [the doc's](https://distribution.github.io/distribution/about/configuration/) this parameter is:

```
A random piece of data used to sign state that may be stored with the client to protect against tampering. ... If you are building a cluster of registries behind a load balancer, you MUST ensure the secret is the same for all registries.

```
