### PR TITLE
PLFM-9207 added api gateway logging

### DIFF
--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -266,7 +266,10 @@ def handler(event, context):
         endpoint_configuration=apigateway.EndpointConfiguration(
             types=[apigateway.EndpointType.PRIVATE],
             vpc_endpoints=[vpc_endpoint]),
-        policy=gateway_resource_policy
+        policy=gateway_resource_policy,
+        deploy_options=apigateway.StageOptions(
+            logging_level=apigateway.MethodLoggingLevel.ERROR
+        )
     )
     # the URL for this gateway is api.url
 


### PR DESCRIPTION
This addresses the Microsoft Defender finding that API Gateways need to have logging turned on.