### PR TITLE
IT-3983: implement automatic IAM key rotation

### DIFF
--- a/docker_fargate/cleanup_lambda/index.py
+++ b/docker_fargate/cleanup_lambda/index.py
@@ -1,0 +1,30 @@
+import boto3
+import logging
+import os
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def handler(event, context):
+    """
+    Triggered by EventBridge when the ECS service reaches SERVICE_STEADY_STATE,
+    meaning the rolling deployment of new tasks (with the rotated credentials) is
+    complete.  At that point it is safe to delete the old IAM access key.
+    """
+    ssm = boto3.client('ssm')
+    try:
+        old_key_id = ssm.get_parameter(Name=os.environ['SSM_PARAM_NAME'])['Parameter']['Value']
+    except ssm.exceptions.ParameterNotFound:
+        logger.info("No pending key deletion found, nothing to do")
+        return
+
+    iam = boto3.client('iam')
+    try:
+        iam.delete_access_key(UserName=os.environ['IAM_USERNAME'], AccessKeyId=old_key_id)
+        logger.info(f"Deleted old IAM access key {old_key_id}")
+    except iam.exceptions.NoSuchEntityException:
+        logger.info(f"Key {old_key_id} was already deleted")
+
+    ssm.delete_parameter(Name=os.environ['SSM_PARAM_NAME'])
+    logger.info("Cleanup complete")

--- a/docker_fargate/docker_fargate_stack.py
+++ b/docker_fargate/docker_fargate_stack.py
@@ -10,8 +10,11 @@ from aws_cdk import (Stack,
     aws_lambda,
     aws_logs as logs,
     aws_wafv2 as wafv2,
+    aws_events as events,
+    aws_events_targets as targets,
     CfnOutput,
     Duration,
+    SecretValue,
     Tags)
 
 import config as config
@@ -82,11 +85,15 @@ class DockerFargateStack(Stack):
 
         # create a user
         user = iam.User(self, "DockerRegistryUser")
-        # create a key pair, storing the secret in Secret Manager
+        # create a key pair, storing both the access key ID and secret in Secrets Manager
+        # as a JSON object so they can be rotated together
         access_key = iam.AccessKey(self, "AccessKey", user=user)
         secret_stored_name = f'{env.get(config.STACK_NAME_PREFIX_CONTEXT)}-DockerFargateStack/{context}/access_key'
-        secret_stored_access_key = sm.Secret(self, secret_stored_name,
-            secret_string_value=access_key.secret_access_key
+        access_key_secret = sm.Secret(self, secret_stored_name,
+            secret_object_value={
+                "access_key_id": SecretValue.unsafe_plain_text(access_key.access_key_id),
+                "secret_access_key": access_key.secret_access_key,
+            }
         )
 
         # give the user S3 access
@@ -108,12 +115,12 @@ class DockerFargateStack(Stack):
                 ecs.Secret.from_secrets_manager(sm_secret, NOTIFICATION_AUTH_SECRET_JSON_KEY),
             HTTP_SECRET_SECRET_JSON_KEY:
                 ecs.Secret.from_secrets_manager(sm_secret, HTTP_SECRET_SECRET_JSON_KEY),
-            "AWS_SECRET_ACCESS_KEY": ecs.Secret.from_secrets_manager(secret_stored_access_key)
+            "AWS_ACCESS_KEY_ID": ecs.Secret.from_secrets_manager(access_key_secret, "access_key_id"),
+            "AWS_SECRET_ACCESS_KEY": ecs.Secret.from_secrets_manager(access_key_secret, "secret_access_key"),
         }
 
         env_vars = get_container_env(env)
         env_vars[BUCKET_NAME]=bucket_name
-        env_vars["AWS_ACCESS_KEY_ID"]=access_key.access_key_id
         env_vars["api_gateway_url"]=api_url
 
         # Build the container image for the registry
@@ -262,6 +269,86 @@ class DockerFargateStack(Stack):
         scalable_target.scale_on_memory_utilization("MemoryScaling",
             target_utilization_percent=50
         )
+
+        # ── Credential rotation ──────────────────────────────────────────────
+        # SSM parameter used to hand the old key ID from the rotation Lambda to
+        # the cleanup Lambda (which runs only after ECS confirms the new tasks
+        # are healthy, making it safe to delete the old key).
+        ssm_param_name = f'/{stack_prefix}/pending-key-deletion'
+        ssm_param_arn = f"arn:aws:ssm:{region}:{self.account}:parameter{ssm_param_name}"
+
+        rotation_lambda = aws_lambda.Function(self, "RotationLambda",
+            runtime=aws_lambda.Runtime.PYTHON_3_13,
+            handler="index.handler",
+            code=aws_lambda.Code.from_asset("docker_fargate/rotation_lambda"),
+            timeout=Duration.minutes(5),
+            environment={
+                "IAM_USERNAME": user.user_name,
+                "SSM_PARAM_NAME": ssm_param_name,
+                "ECS_CLUSTER_ARN": cluster.cluster_arn,
+                "ECS_SERVICE_ARN": load_balanced_fargate_service.service.service_arn,
+            },
+        )
+
+        # Secrets Manager needs read + write on the secret
+        access_key_secret.grant_read(rotation_lambda)
+        rotation_lambda.add_to_role_policy(iam.PolicyStatement(
+            actions=["secretsmanager:PutSecretValue", "secretsmanager:UpdateSecretVersionStage"],
+            resources=[access_key_secret.secret_arn],
+        ))
+        rotation_lambda.add_to_role_policy(iam.PolicyStatement(
+            actions=["iam:CreateAccessKey"],
+            resources=[user.user_arn],
+        ))
+        rotation_lambda.add_to_role_policy(iam.PolicyStatement(
+            actions=["ecs:UpdateService"],
+            resources=[load_balanced_fargate_service.service.service_arn],
+        ))
+        rotation_lambda.add_to_role_policy(iam.PolicyStatement(
+            actions=["ssm:PutParameter"],
+            resources=[ssm_param_arn],
+        ))
+
+        # Wire up 90-day automatic rotation; this also grants Secrets Manager
+        # permission to invoke the Lambda
+        access_key_secret.add_rotation_schedule(
+            "AccessKeyRotationSchedule",
+            rotation_lambda=rotation_lambda,
+            automatically_after=Duration.days(90),
+        )
+
+        cleanup_lambda = aws_lambda.Function(self, "CleanupLambda",
+            runtime=aws_lambda.Runtime.PYTHON_3_13,
+            handler="index.handler",
+            code=aws_lambda.Code.from_asset("docker_fargate/cleanup_lambda"),
+            timeout=Duration.minutes(1),
+            environment={
+                "IAM_USERNAME": user.user_name,
+                "SSM_PARAM_NAME": ssm_param_name,
+            },
+        )
+        cleanup_lambda.add_to_role_policy(iam.PolicyStatement(
+            actions=["iam:DeleteAccessKey"],
+            resources=[user.user_arn],
+        ))
+        cleanup_lambda.add_to_role_policy(iam.PolicyStatement(
+            actions=["ssm:GetParameter", "ssm:DeleteParameter"],
+            resources=[ssm_param_arn],
+        ))
+
+        # Trigger the cleanup Lambda once ECS reports the service is at steady
+        # state (all new tasks healthy), meaning the old credentials are no
+        # longer in use and it is safe to delete the old IAM key
+        events.Rule(self, "ECSDeploymentCompleteRule",
+            event_pattern=events.EventPattern(
+                source=["aws.ecs"],
+                detail_type=["ECS Service Action"],
+                resources=[load_balanced_fargate_service.service.service_arn],
+                detail={"eventName": ["SERVICE_STEADY_STATE"]},
+            ),
+            targets=[targets.LambdaFunction(cleanup_lambda)],
+        )
+        # ── End credential rotation ──────────────────────────────────────────
 
         # Tag all resources in this Stack's scope with context tags
         for key, value in env.get(config.TAGS_CONTEXT).items():

--- a/docker_fargate/rotation_lambda/index.py
+++ b/docker_fargate/rotation_lambda/index.py
@@ -10,6 +10,10 @@ logger.setLevel(logging.INFO)
 
 def handler(event, context):
     secret_arn = event['SecretId']
+    # When Secrets Manager initiates a rotation, it first creates a new pending version of
+    # the secret — a placeholder slot that will hold the new credential once the rotation
+    # Lambda writes it. Secrets Manager generates a UUID to identify that new version,
+    # and passes it to the Lambda as ClientRequestToken.
     token = event['ClientRequestToken']
     step = event['Step']
 

--- a/docker_fargate/rotation_lambda/index.py
+++ b/docker_fargate/rotation_lambda/index.py
@@ -1,0 +1,128 @@
+import boto3
+import json
+import logging
+import os
+import time
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def handler(event, context):
+    secret_arn = event['SecretId']
+    token = event['ClientRequestToken']
+    step = event['Step']
+
+    sm = boto3.client('secretsmanager')
+    metadata = sm.describe_secret(SecretId=secret_arn)
+
+    if not metadata.get('RotationEnabled'):
+        raise ValueError(f"Secret {secret_arn} is not enabled for rotation")
+
+    versions = metadata.get('VersionIdsToStages', {})
+    if token not in versions:
+        raise ValueError(f"Version {token} has no stage for secret {secret_arn}")
+    if 'AWSCURRENT' in versions[token]:
+        logger.info(f"Version {token} is already AWSCURRENT, no rotation needed")
+        return
+    if 'AWSPENDING' not in versions[token]:
+        raise ValueError(f"Version {token} is not AWSPENDING for secret {secret_arn}")
+
+    if step == 'createSecret':
+        create_secret(sm, secret_arn, token)
+    elif step == 'setSecret':
+        pass  # IAM access keys are immediately active after creation
+    elif step == 'testSecret':
+        test_secret(sm, secret_arn, token)
+    elif step == 'finishSecret':
+        finish_secret(sm, secret_arn, token)
+    else:
+        raise ValueError(f"Invalid step: {step}")
+
+
+def create_secret(sm, secret_arn, token):
+    # Idempotency: skip if AWSPENDING version already exists
+    try:
+        sm.get_secret_value(SecretId=secret_arn, VersionId=token, VersionStage='AWSPENDING')
+        logger.info("AWSPENDING version already exists, skipping key creation")
+        return
+    except sm.exceptions.ResourceNotFoundException:
+        pass
+
+    iam = boto3.client('iam')
+    new_key = iam.create_access_key(UserName=os.environ['IAM_USERNAME'])['AccessKey']
+    logger.info(f"Created new IAM access key {new_key['AccessKeyId']}")
+
+    sm.put_secret_value(
+        SecretId=secret_arn,
+        ClientRequestToken=token,
+        SecretString=json.dumps({
+            'access_key_id': new_key['AccessKeyId'],
+            'secret_access_key': new_key['SecretAccessKey'],
+        }),
+        VersionStages=['AWSPENDING'],
+    )
+
+
+def test_secret(sm, secret_arn, token):
+    secret = json.loads(
+        sm.get_secret_value(SecretId=secret_arn, VersionId=token, VersionStage='AWSPENDING')['SecretString']
+    )
+    # IAM key propagation can take a few seconds; retry up to 5 times
+    for attempt in range(5):
+        try:
+            boto3.client(
+                'sts',
+                aws_access_key_id=secret['access_key_id'],
+                aws_secret_access_key=secret['secret_access_key'],
+            ).get_caller_identity()
+            logger.info(f"New key {secret['access_key_id']} tested successfully")
+            return
+        except Exception as e:
+            if attempt == 4:
+                raise
+            logger.warning(f"Test attempt {attempt + 1} failed: {e}, retrying in 5s...")
+            time.sleep(5)
+
+
+def finish_secret(sm, secret_arn, token):
+    metadata = sm.describe_secret(SecretId=secret_arn)
+    current_version = next(
+        (v for v, stages in metadata['VersionIdsToStages'].items() if 'AWSCURRENT' in stages),
+        None,
+    )
+    if current_version == token:
+        logger.info("Version is already AWSCURRENT")
+        return
+
+    # Capture old key ID before promoting the new version
+    old_secret = json.loads(
+        sm.get_secret_value(SecretId=secret_arn, VersionStage='AWSCURRENT')['SecretString']
+    )
+    old_key_id = old_secret['access_key_id']
+
+    # Promote AWSPENDING → AWSCURRENT
+    sm.update_secret_version_stage(
+        SecretId=secret_arn,
+        VersionStage='AWSCURRENT',
+        MoveToVersionId=token,
+        RemoveFromVersionId=current_version,
+    )
+    logger.info(f"Promoted version {token} to AWSCURRENT")
+
+    # Stash old key ID in SSM so the cleanup Lambda can delete it after ECS restarts
+    boto3.client('ssm').put_parameter(
+        Name=os.environ['SSM_PARAM_NAME'],
+        Value=old_key_id,
+        Type='String',
+        Overwrite=True,
+    )
+    logger.info(f"Stored old key ID {old_key_id} in SSM parameter {os.environ['SSM_PARAM_NAME']}")
+
+    # Force a rolling ECS redeployment so tasks pick up the new secret
+    boto3.client('ecs').update_service(
+        cluster=os.environ['ECS_CLUSTER_ARN'],
+        service=os.environ['ECS_SERVICE_ARN'],
+        forceNewDeployment=True,
+    )
+    logger.info("Triggered ECS force redeployment")


### PR DESCRIPTION
IT-3983: implement automatic IAM key rotation

The Synapse Docker registry requires the use of an IAM key pair.  AWS Config flags the key pair (created in Oct., 2024) as requiring rotation.  To address this, rotation can be automated with the Secrets Manager rotation feature, which registers a Lambda to run periodically.  The Lambda has to (1) generate a new key pair, (2) rotate it in Secrets Manager, (3) restart the ECS tasks to pick up the new key pair, and then (4) delete the old key pair to satisfy the AWS Config finding.

The solution was written by Claude Code which provides this summary of the changes:

                                                                                                                                                  
  **New files**                                                                                                                                       
                                                                                                                                                  
  docker_fargate/rotation_lambda/index.py — Secrets Manager rotation Lambda implementing the standard 4-step lifecycle:                           
  - createSecret: creates a new IAM key pair, stores it as AWSPENDING (idempotent)                                                                
  - setSecret: no-op (IAM keys are immediately active)                                                                                            
  - testSecret: calls sts:GetCallerIdentity with the new credentials, with retry for IAM propagation delay
  - finishSecret: promotes AWSPENDING → AWSCURRENT, writes the old key ID to SSM, triggers ecs:UpdateService(forceNewDeployment=True)             
                                                                                                                                                  
  docker_fargate/cleanup_lambda/index.py — Reads the old key ID from SSM, deletes the IAM key, removes the SSM parameter. Safely handles the case 
  where there is no pending deletion (i.e. ECS steady-state events that aren't rotation-related).                                                 
                                                                                                                                                  
  **Modified:** docker_fargate/docker_fargate_stack.py                                                                                                
                                                            
  1. Imports: added aws_events, aws_events_targets, SecretValue                                                                                   
  2. Secret: changed from storing only the secret access key as a plain string to storing both access_key_id and secret_access_key as a JSON
  object (via secret_object_value)                                                                                                                
  3. ECS secrets: AWS_ACCESS_KEY_ID now also injected from the secret (previously it was a plain env var that would go stale after rotation);
  AWS_SECRET_ACCESS_KEY reads the secret_access_key JSON field                                                                                    
  4. Rotation Lambda with least-privilege policies: secretsmanager:PutSecretValue + UpdateSecretVersionStage, iam:CreateAccessKey,
  ecs:UpdateService, ssm:PutParameter                                                                                                             
  5. add_rotation_schedule: wires up 90-day rotation and automatically grants Secrets Manager permission to invoke the Lambda
  6. Cleanup Lambda with least-privilege policies: iam:DeleteAccessKey, ssm:GetParameter + DeleteParameter                                        
  7. EventBridge rule: fires on ECS Service Action / SERVICE_STEADY_STATE for this specific service, triggering the cleanup Lambda  