### PR TITLE
CVE-2026-27459: Bump version of pyOpenSSL to 26.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyOpenSSL==24.2.1
+pyOpenSSL==26.0.0
 aws-cdk-lib==2.194.0
 constructs>=10.0.0,<11.0.0


### PR DESCRIPTION
Update pyOpenSSL to address CVE-2026-27459